### PR TITLE
chore: update docs with correct examples of the AnyCable.broadcast usage

### DIFF
--- a/docs/broadcast_adapters.md
+++ b/docs/broadcast_adapters.md
@@ -93,10 +93,10 @@ With [embedded NATS](../anycable-go/embedded_nats.md) feature of AnyCable, you c
 To publish a message to a stream via AnyCable, you can use the following API:
 
 ```ruby
-AnyCable.broadcast("my_stream", {text: "hoi"})
+AnyCable.broadcast("my_stream", JSON.dump({text: "hoi"}))
 
 # or directly via the singleton broadcast adapter instance
-AnyCable.broadcast_adapter.broadcast("my_stream", {text: "hoi"})
+AnyCable.broadcast_adapter.broadcast("my_stream", JSON.dump({text: "hoi"}))
 ```
 
 ### Batching
@@ -105,8 +105,8 @@ AnyCable-Go v1.4.5+ supports publishing broadcast messages in batches. This is e
 
 ```ruby
 AnyCable.broadcast_adapter.batching do
-  AnyCable.broadcast("my_stream", {text: "hoi"})
-  AnyCable.broadcast("my_stream", {text: "wereld"})
+  AnyCable.broadcast("my_stream", JSON.dump({text: "hoi"}))
+  AnyCable.broadcast("my_stream", JSON.dump({text: "wereld"}))
 end #=> the actual publishing happens as we exit the block
 ```
 
@@ -114,13 +114,13 @@ The `.batching` method supports nesting, if you need to broadcast some messages 
 
 ```ruby
 AnyCable.broadcast_adapter.batching do
-  AnyCable.broadcast("my_stream", {text: "hoi"}) # added to the current batch
+  AnyCable.broadcast("my_stream", "hoi") # added to the current batch
 
   AnyCable.broadcast_adapter.batching(false) do
-    AnyCable.broadcast("another_stream", {text: "some other story"}) #=> publish immediately
+    AnyCable.broadcast("another_stream", "some other story") #=> publish immediately
 
     AnyCable.broadcast_adapter.batching do
-      AnyCable.broadcast("my_stream", {text: "wereld"}) # added to the current batch
+      AnyCable.broadcast("my_stream", "wereld") # added to the current batch
     end
   end
 end #=> the current batch is published
@@ -131,7 +131,7 @@ end #=> the current batch is published
 AnyCable v1.4.5+ supports additional broadcast options. You can pass them as the third argument to the `AnyCable.broadcast` method:
 
 ```ruby
-AnyCable.broadcast("my_stream", {text: "hoi"}, {exclude_socket: "some-socket-id"})
+AnyCable.broadcast("my_stream", JSON.dump({text: "hoi"}), {exclude_socket: "some-socket-id"})
 ```
 
 The following options are supported:


### PR DESCRIPTION
## Summary

Update docs with correct examples of the `AnyCable.broadcast` usage.
Current examples tells that `Hash` can be passed as 2nd parameter. But it is not. It works with ActionCable but not with AnyCable

```
ActionCable.server.broadcast("echo_channel", {text: "hoi"}) # works
AnyCable.broadcast("echo_channel", {text: "hoi"}) # doesn't work
AnyCable.broadcast("echo_channel", JSON.dump({text: "hoi"})) # works
```
