### PR TITLE
Add `log_rpc` option to suppress noisy per-request RPC trace logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add `log_rpc` config option (default: `true`) to suppress per-request RPC trace logs. ([@noah44846][])
+
 ## 1.6.4 (2026-04-02)
 
 - Require MFA to publish the gem.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -19,6 +19,16 @@ AnyCable.logger = MyLogger.new
 
 **IMPORTANT:** When using with Rails, AnyCable automatically sets its logger to `Rails.logger`, so AnyCable-specific logging options are no-op.
 
+## Suppressing RPC trace logs
+
+Per-request RPC trace logs (connect/command/disconnect and broadcast enqueue/perform) can be suppressed with `log_rpc`:
+
+```sh
+$ ANYCABLE_LOG_RPC=false bundle exec anycable
+
+This is useful when using with Rails, where AnyCable.logger is replaced by Rails.logger and log_level has no effect on AnyCable-specific logs. Errors are always logged regardless of this setting.
+```
+
 ## gRPC logging
 
 AnyCable does not log any GRPC internal events by default. You can turn GRPC logger on by setting `log_grpc` parameter to true:

--- a/lib/anycable/broadcast_adapters/http.rb
+++ b/lib/anycable/broadcast_adapters/http.rb
@@ -63,7 +63,7 @@ module AnyCable
 
       def raw_broadcast(payload)
         ensure_thread_is_alive
-        AnyCable.logger.info "Enqueue: #{payload}"
+        AnyCable.logger.info "Enqueue: #{payload}" if AnyCable.config.log_rpc?
         queue << payload
       end
 
@@ -102,7 +102,7 @@ module AnyCable
         build_http do |http|
           req = Net::HTTP::Post.new(url, {"Content-Type" => "application/json"}.merge(headers))
           req.body = payload
-          AnyCable.logger.info "Perform: #{payload}"
+          AnyCable.logger.info "Perform: #{payload}" if AnyCable.config.log_rpc?
           http.request(req)
         end
       end

--- a/lib/anycable/config.rb
+++ b/lib/anycable/config.rb
@@ -63,6 +63,7 @@ module AnyCable
       ### Logging options
       log_file: nil,
       log_level: "info",
+      log_rpc: true, # Set to false to suppress per-request RPC trace logs (connect/command/disconnect/broadcast). Errors are always logged.
       debug: false, # Shortcut to enable debug level and verbose logging
 
       ### Health check options

--- a/lib/anycable/rpc/handlers/command.rb
+++ b/lib/anycable/rpc/handlers/command.rb
@@ -5,7 +5,7 @@ module AnyCable
     module Handlers
       module Command
         def command(message)
-          logger.debug("RPC Command: #{message.inspect}")
+          logger.debug("RPC Command: #{message.inspect}") if AnyCable.config.log_rpc?
 
           socket = build_socket(env: message.env)
 

--- a/lib/anycable/rpc/handlers/connect.rb
+++ b/lib/anycable/rpc/handlers/connect.rb
@@ -5,7 +5,7 @@ module AnyCable
     module Handlers
       module Connect
         def connect(request)
-          logger.debug("RPC Connect: #{request.inspect}")
+          logger.debug("RPC Connect: #{request.inspect}") if AnyCable.config.log_rpc?
 
           socket = build_socket(env: request.env)
 

--- a/lib/anycable/rpc/handlers/disconnect.rb
+++ b/lib/anycable/rpc/handlers/disconnect.rb
@@ -5,7 +5,7 @@ module AnyCable
     module Handlers
       module Disconnect
         def disconnect(request)
-          logger.debug("RPC Disconnect: #{request.inspect}")
+          logger.debug("RPC Disconnect: #{request.inspect}") if AnyCable.config.log_rpc?
 
           socket = build_socket(env: request.env)
 


### PR DESCRIPTION
## Summary

Hey!

When debugging a Rails app with AnyCable, I noticed that every incoming HTTP RPC call (connect/command/disconnect) gets logged with the full request payload — including long session tokens, cookies, and serialized connection data. This makes the Rails log very hard to read when you're trying to follow your application logic, since the RPC trace lines are verbose and repeat information ActionCable already logs in a more readable form.

The root cause is that `anycable-rails` replaces `AnyCable.logger` with `Rails.logger`, so the existing `log_level` and `log_file` config options have no effect — you'd have to lower the log level for your entire Rails app to get rid of the noise, which is not acceptable in my case.

This adds a `log_rpc` config option (default: `true`) to opt out of per-request RPC trace logs while keeping everything else — including errors — untouched. Follows the same pattern as the existing `log_grpc` option.

## Changes

- [x] Add `log_rpc` config option (default: `true`) — set to `false` to suppress per-request `info`/`debug` trace logs in RPC handlers (connect/command/disconnect) and the HTTP broadcast adapter (enqueue/perform). Errors are unaffected.

### Checklist

- [ ] I've added tests for this change — skipped, no existing test pattern for log option behavior in this codebase
- [x] I've added a Changelog entry
- [x] I've updated documentation

---

**Usage:**
```yaml
# anycable.yml
development:
  log_rpc: false
```