### PR TITLE
Set grpc.http2.min_ping_interval_without_data_ms to 5s to avoid too_many_pings

### DIFF
--- a/lib/anycable/grpc/config.rb
+++ b/lib/anycable/grpc/config.rb
@@ -37,13 +37,19 @@ module AnyCable
           tls_credentials: tls_credentials,
           server_args: enhance_grpc_server_args(normalized_grpc_server_args).tap do |sargs|
             # Provide keepalive defaults unless explicitly set.
-            # They must MATCH the corresponding Go client defaults:
-            # https://github.com/anycable/anycable-go/blob/62e77e7f759aa9253c2bd23812dd59ec8471db86/rpc/rpc.go#L512-L515
+            # They must be LESS THAN the corresponding Go client defaults of 10 seconds:
+            # https://github.com/anycable/anycable/blob/main/rpc/rpc.go#L638-L641
+            # If they are set EXACTLY, normal scheduling jitter can make a ping arrive
+            # just under the threshold and accumulate strikes until the server emits
+            # GoAway ENHANCE_YOUR_CALM "too_many_pings", tearing down active RPCs.
+            # Halving the server minimum gives 5s of jitter tolerance against the fixed
+            # 10s client interval.
             #
-            # See also https://github.com/grpc/grpc/blob/master/doc/keepalive.md and https://grpc.github.io/grpc/core/group__grpc__arg__keys.html
+            # See also https://github.com/grpc/grpc/blob/master/doc/keepalive.md 
+            #          https://grpc.github.io/grpc/core/group__grpc__arg__keys.html
+            #          https://github.com/grpc/grpc/issues/25713
             sargs["grpc.keepalive_permit_without_calls"] ||= 1
-            sargs["grpc.http2.min_recv_ping_interval_without_data_ms"] ||= 10_000
-            sargs["grpc.http2.min_ping_interval_without_data_ms"] ||= 10_000
+            sargs["grpc.http2.min_ping_interval_without_data_ms"] ||= 5_000
           end
         }
       end


### PR DESCRIPTION
## Summary
Per https://github.com/grpc/grpc/blob/master/doc/keepalive.md and https://github.com/grpc/grpc/issues/25713 it is tricky to get the keep alive ping setting correct. In our own application using anycable I've seen the following errors:

```
2026/04/24 18:33:39 ERROR: [transport] Client received GoAway with error code ENHANCE_YOUR_CALM and debug data equal to ASCII "too_many_pings".
```

This seemed to have improved over time so I don't know if some of the settings have changed but I think it is still incorrect. Based on a lot of reading it appears the server minimum has to be strictly lower than the client interval or jitter produces strikes. You had them set exactly the same. Since the client is hard coded to 10 I set the server to 5.

More information is available here: https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md

Also I remove the key that had no effect. The key that matters is `grpc.http2.min_ping_interval_without_data_ms` as documented here: https://grpc.github.io/grpc/core/group__grpc__arg__keys.html