### PR TITLE
Fix: ANYCABLE_REDIS_TLS_CA_CERT_PATH config option ignored

### DIFF
--- a/lib/anycable/config.rb
+++ b/lib/anycable/config.rb
@@ -194,7 +194,7 @@ module AnyCable
         if cert_path && key_path
           ssl_params[:cert] = OpenSSL::X509::Certificate.new(File.read(cert_path))
           ssl_params[:key] = OpenSSL::PKey.read(File.read(key_path))
-          ssl_params[:ca_path] if ca_path
+          ssl_params[:ca_file] = ca_path if ca_path
         end
 
         if !redis_tls_verify?

--- a/spec/anycable/config_spec.rb
+++ b/spec/anycable/config_spec.rb
@@ -153,6 +153,54 @@ describe AnyCable::Config do
         )
       end
     end
+
+    context "with TLS and CA certificate path" do
+      subject(:config) { described_class.new }
+
+      let(:client_cert_path) { "/__anycable_spec__/client.pem" }
+      let(:client_key_path) { "/__anycable_spec__/client.key" }
+      let(:ca_cert_path) { "/__anycable_spec__/ca.pem" }
+      let(:stub_cert_pem) { "STUB_CLIENT_CERT_PEM" }
+      let(:stub_key_pem) { "STUB_CLIENT_KEY_PEM" }
+      let(:stub_cert) { instance_double(OpenSSL::X509::Certificate) }
+      let(:stub_key) { instance_double(OpenSSL::PKey::PKey) }
+
+      around do |ex|
+        with_env(
+          "ANYCABLE_REDIS_URL" => "rediss://localhost:6379/3",
+          "ANYCABLE_REDIS_TLS_VERIFY" => "1",
+          "ANYCABLE_REDIS_TLS_CLIENT_CERT_PATH" => client_cert_path,
+          "ANYCABLE_REDIS_TLS_CLIENT_KEY_PATH" => client_key_path,
+          "ANYCABLE_REDIS_TLS_CA_CERT_PATH" => ca_cert_path,
+          "ANYCABLE_REDIS_SENTINELS" => "",
+          &ex
+        )
+      end
+
+      before do
+        allow(File).to receive(:read).and_wrap_original do |original, path|
+          case path
+          when client_cert_path then stub_cert_pem
+          when client_key_path then stub_key_pem
+          else original.call(path)
+          end
+        end
+
+        allow(OpenSSL::X509::Certificate).to receive(:new).with(stub_cert_pem).and_return(stub_cert)
+        allow(OpenSSL::PKey).to receive(:read).with(stub_key_pem).and_return(stub_key)
+      end
+
+      specify do
+        expect(subject.to_redis_params).to eq(
+          url: "rediss://localhost:6379/3",
+          ssl_params: {
+            cert: stub_cert,
+            key: stub_key,
+            ca_file: ca_cert_path
+          }
+        )
+      end
+    end
   end
 
   describe "#to_nats_params" do


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## Summary

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

## Changes

- [x] Actually use redis_tls_ca_cert_path config for ssl_params
- [x] Use :ca_file* option for OpenSSL::SSL::SSLContext#set_params instead of not used :ca_path*

### Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated documentation

---

*see https://ruby.github.io/openssl/OpenSSL/SSL/SSLContext.html#attribute-i-ca_file 
- ca_file: The path to a file containing a PEM-format CA certificate 
- ca_path: The path to a directory containing CA certificates in PEM format.
