### PR TITLE
Feature: Postgres signalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add Postgres broadcast adapter. ([@TikiTDO][])
+
 ## 1.6.4 (2026-04-02)
 
 - Require MFA to publish the gem.
@@ -245,3 +247,4 @@ See [Changelog](https://github.com/anycable/anycable-rb/blob/0-6-stable/CHANGELO
 [@cylon-v]: https://github.com/cylon-v
 [@earlopain]: https://github.com/earlopain
 [@le0pard]: https://github.com/le0pard
+[@TikiTDO]: https://github.com/TikiTDO

--- a/anycable-core.gemspec
+++ b/anycable-core.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "redis", ">= 4.0"
   spec.add_development_dependency "nats-pure", "~> 2"
+  spec.add_development_dependency "pg", ">= 1.4"
 
   spec.add_development_dependency "bundler", ">= 1"
   spec.add_development_dependency "rake", ">= 13.0"

--- a/docs/broadcast_adapters.md
+++ b/docs/broadcast_adapters.md
@@ -1,6 +1,6 @@
 # Broadcasting
 
-AnyCable supports multiple ways of publishing messages from your backend to connected clients: HTTP API, Redis and [NATS][]-backed.
+AnyCable supports multiple ways of publishing messages from your backend to connected clients: HTTP API, Redis, [NATS][], and Postgres-backed.
 
 AnyCable Ruby provides a universal API to publish broadcast messages from your Ruby/Rails applications independently of which underlying technology you would like to use. All you need is to pick and configure an adapter.
 
@@ -87,6 +87,32 @@ The following configuration options are available:
   NATS pus/sub channel for broadcasting (default: `"__anycable__"`).
 
 With [embedded NATS](../anycable-go/embedded_nats.md) feature of AnyCable, you can minimize the number of required components to deploy an AnyCable-backed application.
+
+### Postgres
+
+> Enable via `broadcast_adapter: postgres` in `anycable.yml` or `ANYCABLE_BROADCAST_ADAPTER=postgres`.
+
+**NOTE:** Make sure you added the `pg` gem to your Gemfile.
+
+The Postgres adapter inserts the full AnyCable broadcast JSON envelope into the `anycable_broadcasts` table. anycable-go reads payloads from the table; PostgreSQL `LISTEN/NOTIFY` is used only as a wake-up signal, so broadcasts are not limited by the `NOTIFY` payload size.
+
+The following configuration options are available:
+
+- **postgres_url** (`ANYCABLE_POSTGRES_URL`, or `DATABASE_URL` by default)
+
+  Postgres connection URL.
+
+- **postgres_broadcasts_table** (`ANYCABLE_POSTGRES_BROADCASTS_TABLE`)
+
+  Table used to enqueue app-to-AnyCable broadcasts (default: `"anycable_broadcasts"`).
+
+- **postgres_contract_table** (`ANYCABLE_POSTGRES_CONTRACT_TABLE`)
+
+  Table used to validate the installed signalling contract (default: `"anycable_contracts"`).
+
+- **postgres_validate_contract** (`ANYCABLE_POSTGRES_VALIDATE_CONTRACT`)
+
+  Validate the contract version, broadcast table columns, and trigger when the adapter starts (default: `true`).
 
 ## Broadcasting API
 

--- a/docs/broadcast_adapters.md
+++ b/docs/broadcast_adapters.md
@@ -94,25 +94,16 @@ With [embedded NATS](../anycable-go/embedded_nats.md) feature of AnyCable, you c
 
 **NOTE:** Make sure you added the `pg` gem to your Gemfile.
 
-The Postgres adapter inserts the full AnyCable broadcast JSON envelope into the `anycable_broadcasts` table. anycable-go reads payloads from the table; PostgreSQL `LISTEN/NOTIFY` is used only as a wake-up signal, so broadcasts are not limited by the `NOTIFY` payload size.
+The Postgres adapter sends the full AnyCable broadcast JSON envelope through the
+SQL functions owned by anycable-go. anycable-go stores payloads in Postgres and
+uses PostgreSQL `LISTEN/NOTIFY` only as a wake-up signal, so broadcasts are not
+limited by the `NOTIFY` payload size.
 
 The following configuration options are available:
 
 - **postgres_url** (`ANYCABLE_POSTGRES_URL`, or `DATABASE_URL` by default)
 
   Postgres connection URL.
-
-- **postgres_broadcasts_table** (`ANYCABLE_POSTGRES_BROADCASTS_TABLE`)
-
-  Table used to enqueue app-to-AnyCable broadcasts (default: `"anycable_broadcasts"`).
-
-- **postgres_contract_table** (`ANYCABLE_POSTGRES_CONTRACT_TABLE`)
-
-  Table used to validate the installed signalling contract (default: `"anycable_contracts"`).
-
-- **postgres_validate_contract** (`ANYCABLE_POSTGRES_VALIDATE_CONTRACT`)
-
-  Validate the contract version, broadcast table columns, and trigger when the adapter starts (default: `true`).
 
 ## Broadcasting API
 

--- a/lib/anycable/broadcast_adapters/postgres.rb
+++ b/lib/anycable/broadcast_adapters/postgres.rb
@@ -89,12 +89,14 @@ module AnyCable
             WHERE tgrelid = to_regclass($1)
               AND tgname = $2
               AND NOT tgisinternal
+              AND tgenabled <> 'D'
+              AND (tgtype::int & 4) = 4
           )
         SQL
 
         return if result.getvalue(0, 0) == "t"
 
-        raise "Postgres signalling table #{table} is missing trigger #{BROADCASTS_TRIGGER_NAME}"
+        raise "Postgres signalling table #{table} is missing enabled INSERT trigger #{BROADCASTS_TRIGGER_NAME}"
       end
 
       def expected_columns

--- a/lib/anycable/broadcast_adapters/postgres.rb
+++ b/lib/anycable/broadcast_adapters/postgres.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+begin
+  require "pg"
+rescue LoadError
+  raise "Please, install the pg gem to use Postgres broadcast adapter"
+end
+
+require "json"
+
+module AnyCable
+  module BroadcastAdapters
+    # Postgres adapter for broadcasting.
+    #
+    # It writes the full AnyCable broadcast JSON envelope into the shared
+    # signalling table. The database trigger emits a tiny NOTIFY wake-up, while
+    # anycable-go reads the actual payload back from Postgres.
+    class Postgres < Base
+      CONTRACT_NAME = "postgres_signalling"
+      CONTRACT_VERSION = 1
+      BROADCASTS_TRIGGER_NAME = "anycable_broadcasts_notify_insert"
+
+      attr_reader :pg_conn, :table, :contract_table
+
+      def initialize(**options)
+        options = AnyCable.config.to_postgres_params.merge(options)
+
+        @pg_conn = options.delete(:connection) || ::PG.connect(options.fetch(:url))
+        @broadcasts_table_name = options.fetch(:broadcasts_table)
+        @contract_table_name = options.fetch(:contract_table)
+        @table = quote_table_name(@broadcasts_table_name)
+        @contract_table = quote_table_name(@contract_table_name)
+
+        validate_contract! if options.fetch(:validate_contract)
+      end
+
+      def raw_broadcast(payload)
+        pg_conn.exec_params("INSERT INTO #{table} (payload) VALUES ($1)", [payload])
+      end
+
+      def announce!
+        logger.info "Broadcasting Postgres table: #{table}"
+      end
+
+      private
+
+      def validate_contract!
+        result = pg_conn.exec_params("SELECT version FROM #{contract_table} WHERE name = $1", [CONTRACT_NAME])
+        version = result.ntuples.positive? ? result.getvalue(0, 0).to_i : nil
+
+        unless version == CONTRACT_VERSION
+          raise "Postgres signalling contract version mismatch: expected #{CONTRACT_VERSION}, got #{version || "missing"}"
+        end
+
+        validate_columns!
+        validate_trigger!
+      end
+
+      def validate_columns!
+        result = pg_conn.exec_params(<<~SQL, [@broadcasts_table_name])
+          SELECT a.attname, pg_catalog.format_type(a.atttypid, a.atttypmod), a.attnotnull
+          FROM pg_catalog.pg_attribute a
+          WHERE a.attrelid = to_regclass($1)
+            AND a.attnum > 0
+            AND NOT a.attisdropped
+        SQL
+
+        columns = result.each_with_object({}) do |row, memo|
+          memo[row["attname"]] = row
+        end
+
+        expected_columns.each do |name, type, required|
+          column = columns[name]
+          raise "Postgres signalling table #{table} is missing required column #{name}" unless column
+          raise "Postgres signalling table #{table} column #{name} has type #{column["format_type"]}; expected #{type}" unless column["format_type"] == type
+
+          next unless required
+          next if column["attnotnull"].to_s == "t" || column["attnotnull"] == true
+
+          raise "Postgres signalling table #{table} column #{name} must be NOT NULL"
+        end
+      end
+
+      def validate_trigger!
+        result = pg_conn.exec_params(<<~SQL, [@broadcasts_table_name, BROADCASTS_TRIGGER_NAME])
+          SELECT EXISTS (
+            SELECT 1
+            FROM pg_catalog.pg_trigger
+            WHERE tgrelid = to_regclass($1)
+              AND tgname = $2
+              AND NOT tgisinternal
+          )
+        SQL
+
+        return if result.getvalue(0, 0) == "t"
+
+        raise "Postgres signalling table #{table} is missing trigger #{BROADCASTS_TRIGGER_NAME}"
+      end
+
+      def expected_columns
+        [
+          ["id", "bigint", true],
+          ["payload", "text", true],
+          ["claimed_by", "text", false],
+          ["claimed_at", "timestamp with time zone", false],
+          ["attempts", "integer", true],
+          ["last_error", "text", false],
+          ["created_at", "timestamp with time zone", true]
+        ]
+      end
+
+      def quote_table_name(name)
+        parts = name.to_s.split(".")
+        raise ArgumentError, "Postgres table name cannot be empty" if parts.empty? || parts.any?(&:empty?)
+        raise ArgumentError, "Postgres table name must be table or schema.table" if parts.size > 2
+
+        parts.map { |part| ::PG::Connection.quote_ident(part) }.join(".")
+      end
+    end
+  end
+end

--- a/lib/anycable/broadcast_adapters/postgres.rb
+++ b/lib/anycable/broadcast_adapters/postgres.rb
@@ -12,111 +12,55 @@ module AnyCable
   module BroadcastAdapters
     # Postgres adapter for broadcasting.
     #
-    # It writes the full AnyCable broadcast JSON envelope into the shared
-    # signalling table. The database trigger emits a tiny NOTIFY wake-up, while
-    # anycable-go reads the actual payload back from Postgres.
+    # It writes the full AnyCable broadcast JSON envelope through the SQL
+    # functions owned by anycable-go. The payload is stored as opaque text in
+    # Postgres; routing metadata is handled by the server-owned schema.
     class Postgres < Base
-      CONTRACT_NAME = "postgres_signalling"
-      CONTRACT_VERSION = 1
-      BROADCASTS_TRIGGER_NAME = "anycable_broadcasts_notify_insert"
+      PUBLISH_FUNCTION = "anycable_publish"
+      REMOTE_COMMAND_FUNCTION = "anycable_remote_command"
 
-      attr_reader :pg_conn, :table, :contract_table
+      attr_reader :pg_conn
 
       def initialize(**options)
         options = AnyCable.config.to_postgres_params.merge(options)
 
         @pg_conn = options.delete(:connection) || ::PG.connect(options.fetch(:url))
-        @broadcasts_table_name = options.fetch(:broadcasts_table)
-        @contract_table_name = options.fetch(:contract_table)
-        @table = quote_table_name(@broadcasts_table_name)
-        @contract_table = quote_table_name(@contract_table_name)
-
-        validate_contract! if options.fetch(:validate_contract)
       end
 
       def raw_broadcast(payload)
-        pg_conn.exec_params("INSERT INTO #{table} (payload) VALUES ($1)", [payload])
+        message = JSON.parse(payload)
+
+        if message.is_a?(Array)
+          message.each { |item| publish_message(item, JSON.generate(item)) }
+        else
+          publish_message(message, payload)
+        end
       end
 
       def announce!
-        logger.info "Broadcasting Postgres table: #{table}"
+        logger.info "Broadcasting Postgres functions: #{PUBLISH_FUNCTION}, #{REMOTE_COMMAND_FUNCTION}"
       end
 
       private
 
-      def validate_contract!
-        result = pg_conn.exec_params("SELECT version FROM #{contract_table} WHERE name = $1", [CONTRACT_NAME])
-        version = result.ntuples.positive? ? result.getvalue(0, 0).to_i : nil
-
-        unless version == CONTRACT_VERSION
-          raise "Postgres signalling contract version mismatch: expected #{CONTRACT_VERSION}, got #{version || "missing"}"
+      def publish_message(message, payload)
+        unless message.is_a?(Hash)
+          raise ArgumentError, "Postgres broadcast payload must be a JSON object or array of objects"
         end
 
-        validate_columns!
-        validate_trigger!
-      end
-
-      def validate_columns!
-        result = pg_conn.exec_params(<<~SQL, [@broadcasts_table_name])
-          SELECT a.attname, pg_catalog.format_type(a.atttypid, a.atttypmod), a.attnotnull
-          FROM pg_catalog.pg_attribute a
-          WHERE a.attrelid = to_regclass($1)
-            AND a.attnum > 0
-            AND NOT a.attisdropped
-        SQL
-
-        columns = result.each_with_object({}) do |row, memo|
-          memo[row["attname"]] = row
-        end
-
-        expected_columns.each do |name, type, required|
-          column = columns[name]
-          raise "Postgres signalling table #{table} is missing required column #{name}" unless column
-          raise "Postgres signalling table #{table} column #{name} has type #{column["format_type"]}; expected #{type}" unless column["format_type"] == type
-
-          next unless required
-          next if column["attnotnull"].to_s == "t" || column["attnotnull"] == true
-
-          raise "Postgres signalling table #{table} column #{name} must be NOT NULL"
-        end
-      end
-
-      def validate_trigger!
-        result = pg_conn.exec_params(<<~SQL, [@broadcasts_table_name, BROADCASTS_TRIGGER_NAME])
-          SELECT EXISTS (
-            SELECT 1
-            FROM pg_catalog.pg_trigger
-            WHERE tgrelid = to_regclass($1)
-              AND tgname = $2
-              AND NOT tgisinternal
-              AND tgenabled <> 'D'
-              AND (tgtype::int & 4) = 4
+        if message.key?("stream")
+          pg_conn.exec_params(
+            "SELECT #{PUBLISH_FUNCTION}($1, $2, $3)",
+            [message.fetch("stream"), payload, JSON.generate(message.fetch("meta", {}))]
           )
-        SQL
-
-        return if result.getvalue(0, 0) == "t"
-
-        raise "Postgres signalling table #{table} is missing enabled INSERT trigger #{BROADCASTS_TRIGGER_NAME}"
-      end
-
-      def expected_columns
-        [
-          ["id", "bigint", true],
-          ["payload", "text", true],
-          ["claimed_by", "text", false],
-          ["claimed_at", "timestamp with time zone", false],
-          ["attempts", "integer", true],
-          ["last_error", "text", false],
-          ["created_at", "timestamp with time zone", true]
-        ]
-      end
-
-      def quote_table_name(name)
-        parts = name.to_s.split(".")
-        raise ArgumentError, "Postgres table name cannot be empty" if parts.empty? || parts.any?(&:empty?)
-        raise ArgumentError, "Postgres table name must be table or schema.table" if parts.size > 2
-
-        parts.map { |part| ::PG::Connection.quote_ident(part) }.join(".")
+        elsif message.key?("command")
+          pg_conn.exec_params(
+            "SELECT #{REMOTE_COMMAND_FUNCTION}($1, $2)",
+            [payload, JSON.generate(message.fetch("meta", {}))]
+          )
+        else
+          raise ArgumentError, "Postgres broadcast payload must include stream or command"
+        end
       end
     end
   end

--- a/lib/anycable/config.rb
+++ b/lib/anycable/config.rb
@@ -55,6 +55,12 @@ module AnyCable
       nats_dont_randomize_servers: false,
       nats_options: {},
 
+      ### Postgres broadcasting options
+      postgres_url: ENV.fetch("DATABASE_URL", "postgres://localhost:5432/postgres?sslmode=disable"),
+      postgres_broadcasts_table: "anycable_broadcasts",
+      postgres_contract_table: "anycable_contracts",
+      postgres_validate_contract: true,
+
       ### HTTP broadcasting options
       http_broadcast_url: nil,
       # DEPRECATED: use `broadcast_key` instead
@@ -83,11 +89,12 @@ module AnyCable
       nats_servers: {type: nil, array: true},
       redis_tls_verify: :boolean,
       nats_dont_randomize_servers: :boolean,
+      postgres_validate_contract: :boolean,
       debug: :boolean,
       version_check_enabled: :boolean
     )
 
-    flag_options :debug, :nats_dont_randomize_servers
+    flag_options :debug, :nats_dont_randomize_servers, :postgres_validate_contract
     ignore_options :nats_options
 
     def load(*_args)
@@ -159,6 +166,12 @@ module AnyCable
           --nats-channel=name               NATS channel for broadcasting, default: "__anycable__"
           --nats-dont-randomize-servers     Pass this option to disable NATS servers randomization during (re-)connect
 
+      POSTGRES
+          --postgres-url=url                 Postgres URL for broadcasting, default: DATABASE_URL or "postgres://localhost:5432/postgres?sslmode=disable"
+          --postgres-broadcasts-table=name   Postgres broadcasts table, default: "anycable_broadcasts"
+          --postgres-contract-table=name     Postgres contract table, default: "anycable_contracts"
+          --postgres-validate-contract       Validate Postgres signalling contract on adapter startup
+
       HTTP BROADCASTING
           --http-broadcast-url              HTTP broadcasting endpoint URL, default: "http://localhost:8090/_broadcast"
 
@@ -211,6 +224,15 @@ module AnyCable
         servers: Array(nats_servers),
         dont_randomize_servers: nats_dont_randomize_servers
       }.merge(nats_options)
+    end
+
+    def to_postgres_params
+      {
+        url: postgres_url,
+        broadcasts_table: postgres_broadcasts_table,
+        contract_table: postgres_contract_table,
+        validate_contract: postgres_validate_contract?
+      }
     end
 
     # Build HTTP health server parameters

--- a/lib/anycable/config.rb
+++ b/lib/anycable/config.rb
@@ -57,9 +57,6 @@ module AnyCable
 
       ### Postgres broadcasting options
       postgres_url: ENV.fetch("DATABASE_URL", "postgres://localhost:5432/postgres?sslmode=disable"),
-      postgres_broadcasts_table: "anycable_broadcasts",
-      postgres_contract_table: "anycable_contracts",
-      postgres_validate_contract: true,
 
       ### HTTP broadcasting options
       http_broadcast_url: nil,
@@ -89,12 +86,11 @@ module AnyCable
       nats_servers: {type: nil, array: true},
       redis_tls_verify: :boolean,
       nats_dont_randomize_servers: :boolean,
-      postgres_validate_contract: :boolean,
       debug: :boolean,
       version_check_enabled: :boolean
     )
 
-    flag_options :debug, :nats_dont_randomize_servers, :postgres_validate_contract
+    flag_options :debug, :nats_dont_randomize_servers
     ignore_options :nats_options
 
     def load(*_args)
@@ -168,9 +164,6 @@ module AnyCable
 
       POSTGRES
           --postgres-url=url                 Postgres URL for broadcasting, default: DATABASE_URL or "postgres://localhost:5432/postgres?sslmode=disable"
-          --postgres-broadcasts-table=name   Postgres broadcasts table, default: "anycable_broadcasts"
-          --postgres-contract-table=name     Postgres contract table, default: "anycable_contracts"
-          --postgres-validate-contract       Validate Postgres signalling contract on adapter startup
 
       HTTP BROADCASTING
           --http-broadcast-url              HTTP broadcasting endpoint URL, default: "http://localhost:8090/_broadcast"
@@ -228,10 +221,7 @@ module AnyCable
 
     def to_postgres_params
       {
-        url: postgres_url,
-        broadcasts_table: postgres_broadcasts_table,
-        contract_table: postgres_contract_table,
-        validate_contract: postgres_validate_contract?
+        url: postgres_url
       }
     end
 

--- a/sig/anycable/broadcast_adapters/postgres.rbs
+++ b/sig/anycable/broadcast_adapters/postgres.rbs
@@ -1,0 +1,15 @@
+module AnyCable
+  module BroadcastAdapters
+    class Postgres < Base
+      CONTRACT_NAME: String
+      CONTRACT_VERSION: Integer
+      BROADCASTS_TRIGGER_NAME: String
+
+      attr_reader pg_conn: untyped
+      attr_reader table: String
+      attr_reader contract_table: String
+
+      def initialize: (**untyped options) -> void
+    end
+  end
+end

--- a/sig/anycable/broadcast_adapters/postgres.rbs
+++ b/sig/anycable/broadcast_adapters/postgres.rbs
@@ -1,13 +1,10 @@
 module AnyCable
   module BroadcastAdapters
     class Postgres < Base
-      CONTRACT_NAME: String
-      CONTRACT_VERSION: Integer
-      BROADCASTS_TRIGGER_NAME: String
+      PUBLISH_FUNCTION: String
+      REMOTE_COMMAND_FUNCTION: String
 
       attr_reader pg_conn: untyped
-      attr_reader table: String
-      attr_reader contract_table: String
 
       def initialize: (**untyped options) -> void
     end

--- a/sig/anycable/config.rbs
+++ b/sig/anycable/config.rbs
@@ -40,13 +40,6 @@ module AnyCable
     def nats_options=: (Hash[untyped, untyped]) -> void
     def postgres_url: () -> String
     def postgres_url=: (String) -> void
-    def postgres_broadcasts_table: () -> String
-    def postgres_broadcasts_table=: (String) -> void
-    def postgres_contract_table: () -> String
-    def postgres_contract_table=: (String) -> void
-    def postgres_validate_contract: () -> bool
-    def postgres_validate_contract=: (bool) -> void
-    def postgres_validate_contract?: () -> bool
     def http_broadcast_url: () -> String
     def http_broadcast_url=: (String) -> void
     def http_broadcast_secret: () -> String?
@@ -92,7 +85,7 @@ module AnyCable
     def to_redis_params: () -> { url: String, sentinels: Array[untyped]?, ssl_params: Hash[Symbol, untyped]? }
     def to_http_health_params: () -> { port: Integer?, path: String }
     def to_nats_params: () -> Hash[Symbol, untyped]
-    def to_postgres_params: () -> { url: String, broadcasts_table: String, contract_table: String, validate_contract: bool }
+    def to_postgres_params: () -> { url: String }
 
     private
 

--- a/sig/anycable/config.rbs
+++ b/sig/anycable/config.rbs
@@ -38,6 +38,15 @@ module AnyCable
     def nats_dont_randomize_servers?: () -> bool
     def nats_options: () -> Hash[untyped, untyped]
     def nats_options=: (Hash[untyped, untyped]) -> void
+    def postgres_url: () -> String
+    def postgres_url=: (String) -> void
+    def postgres_broadcasts_table: () -> String
+    def postgres_broadcasts_table=: (String) -> void
+    def postgres_contract_table: () -> String
+    def postgres_contract_table=: (String) -> void
+    def postgres_validate_contract: () -> bool
+    def postgres_validate_contract=: (bool) -> void
+    def postgres_validate_contract?: () -> bool
     def http_broadcast_url: () -> String
     def http_broadcast_url=: (String) -> void
     def http_broadcast_secret: () -> String?
@@ -83,6 +92,7 @@ module AnyCable
     def to_redis_params: () -> { url: String, sentinels: Array[untyped]?, ssl_params: Hash[Symbol, untyped]? }
     def to_http_health_params: () -> { port: Integer?, path: String }
     def to_nats_params: () -> Hash[Symbol, untyped]
+    def to_postgres_params: () -> { url: String, broadcasts_table: String, contract_table: String, validate_contract: bool }
 
     private
 

--- a/spec/anycable/broadcast_adapters/postgres_spec.rb
+++ b/spec/anycable/broadcast_adapters/postgres_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "anycable/broadcast_adapters/postgres"
+
+describe AnyCable::BroadcastAdapters::Postgres do
+  let(:pg_conn) { instance_double("PG::Connection") }
+
+  before do
+    config.postgres_url = "postgres://postgres-1/anycable"
+    config.postgres_broadcasts_table = "anycable_broadcasts"
+    config.postgres_contract_table = "anycable_contracts"
+    config.postgres_validate_contract = false
+
+    allow(::PG).to receive(:connect) { pg_conn }
+  end
+
+  after { AnyCable.config.reload }
+
+  let(:config) { AnyCable.config }
+
+  it "uses config options by default" do
+    adapter = described_class.new
+
+    expect(adapter.table).to eq "\"anycable_broadcasts\""
+    expect(PG).to have_received(:connect).with("postgres://postgres-1/anycable")
+  end
+
+  it "uses override config params" do
+    adapter = described_class.new(url: "postgres://local.pg/anycable", broadcasts_table: "public.anycable_broadcasts")
+
+    expect(adapter.table).to eq "\"public\".\"anycable_broadcasts\""
+    expect(PG).to have_received(:connect).with("postgres://local.pg/anycable")
+  end
+
+  describe "#announce" do
+    around do |ex|
+      old_logger = AnyCable.logger
+      AnyCable.remove_instance_variable(:@logger)
+      ex.run
+      AnyCable.logger = old_logger
+      AnyCable.config.reload
+    end
+
+    specify do
+      expect { described_class.new.announce! }.to output(/Broadcasting Postgres table: "anycable_broadcasts"/).to_stdout_from_any_process
+    end
+  end
+
+  describe "#broadcast" do
+    it "inserts stream data into the broadcast table" do
+      allow(pg_conn).to receive(:exec_params)
+
+      adapter = described_class.new
+      adapter.broadcast("notification", "hello!")
+
+      expect(pg_conn).to have_received(:exec_params).with(
+        "INSERT INTO \"anycable_broadcasts\" (payload) VALUES ($1)",
+        [{stream: "notification", data: "hello!"}.to_json]
+      )
+    end
+  end
+
+  describe "#broadcast_command" do
+    it "inserts command data into the broadcast table" do
+      allow(pg_conn).to receive(:exec_params)
+
+      adapter = described_class.new
+      adapter.broadcast_command("disconnect", identifier: "42")
+
+      expect(pg_conn).to have_received(:exec_params).with(
+        "INSERT INTO \"anycable_broadcasts\" (payload) VALUES ($1)",
+        [{command: "disconnect", payload: {identifier: "42"}}.to_json]
+      )
+    end
+  end
+
+  describe "contract validation" do
+    before do
+      config.postgres_validate_contract = true
+    end
+
+    let(:version_result) do
+      instance_double("PG::Result", ntuples: 1, getvalue: "1")
+    end
+
+    let(:columns_result) do
+      [
+        {"attname" => "id", "format_type" => "bigint", "attnotnull" => "t"},
+        {"attname" => "payload", "format_type" => "text", "attnotnull" => "t"},
+        {"attname" => "claimed_by", "format_type" => "text", "attnotnull" => "f"},
+        {"attname" => "claimed_at", "format_type" => "timestamp with time zone", "attnotnull" => "f"},
+        {"attname" => "attempts", "format_type" => "integer", "attnotnull" => "t"},
+        {"attname" => "last_error", "format_type" => "text", "attnotnull" => "f"},
+        {"attname" => "created_at", "format_type" => "timestamp with time zone", "attnotnull" => "t"}
+      ]
+    end
+
+    let(:trigger_result) do
+      instance_double("PG::Result", getvalue: "t")
+    end
+
+    it "checks contract version, columns, and trigger" do
+      allow(pg_conn).to receive(:exec_params).and_return(version_result, columns_result, trigger_result)
+
+      expect { described_class.new }.not_to raise_error
+    end
+
+    it "fails when the contract row is missing" do
+      missing_version = instance_double("PG::Result", ntuples: 0)
+      allow(pg_conn).to receive(:exec_params).and_return(missing_version)
+
+      expect { described_class.new }.to raise_error(/contract version mismatch/)
+    end
+  end
+end

--- a/spec/anycable/broadcast_adapters/postgres_spec.rb
+++ b/spec/anycable/broadcast_adapters/postgres_spec.rb
@@ -105,6 +105,10 @@ describe AnyCable::BroadcastAdapters::Postgres do
       allow(pg_conn).to receive(:exec_params).and_return(version_result, columns_result, trigger_result)
 
       expect { described_class.new }.not_to raise_error
+      expect(pg_conn).to have_received(:exec_params).with(
+        a_string_matching(/tgenabled <> 'D'.*\(tgtype::int & 4\) = 4/m),
+        ["anycable_broadcasts", described_class::BROADCASTS_TRIGGER_NAME]
+      )
     end
 
     it "fails when the contract row is missing" do

--- a/spec/anycable/broadcast_adapters/postgres_spec.rb
+++ b/spec/anycable/broadcast_adapters/postgres_spec.rb
@@ -9,9 +9,6 @@ describe AnyCable::BroadcastAdapters::Postgres do
 
   before do
     config.postgres_url = "postgres://postgres-1/anycable"
-    config.postgres_broadcasts_table = "anycable_broadcasts"
-    config.postgres_contract_table = "anycable_contracts"
-    config.postgres_validate_contract = false
 
     allow(::PG).to receive(:connect) { pg_conn }
   end
@@ -21,16 +18,14 @@ describe AnyCable::BroadcastAdapters::Postgres do
   let(:config) { AnyCable.config }
 
   it "uses config options by default" do
-    adapter = described_class.new
+    described_class.new
 
-    expect(adapter.table).to eq "\"anycable_broadcasts\""
     expect(PG).to have_received(:connect).with("postgres://postgres-1/anycable")
   end
 
   it "uses override config params" do
-    adapter = described_class.new(url: "postgres://local.pg/anycable", broadcasts_table: "public.anycable_broadcasts")
+    described_class.new(url: "postgres://local.pg/anycable")
 
-    expect(adapter.table).to eq "\"public\".\"anycable_broadcasts\""
     expect(PG).to have_received(:connect).with("postgres://local.pg/anycable")
   end
 
@@ -44,78 +39,78 @@ describe AnyCable::BroadcastAdapters::Postgres do
     end
 
     specify do
-      expect { described_class.new.announce! }.to output(/Broadcasting Postgres table: "anycable_broadcasts"/).to_stdout_from_any_process
+      expect { described_class.new.announce! }.to output(/Broadcasting Postgres functions: anycable_publish, anycable_remote_command/).to_stdout_from_any_process
     end
   end
 
   describe "#broadcast" do
-    it "inserts stream data into the broadcast table" do
+    it "publishes stream data through the Postgres function" do
       allow(pg_conn).to receive(:exec_params)
 
       adapter = described_class.new
       adapter.broadcast("notification", "hello!")
 
       expect(pg_conn).to have_received(:exec_params).with(
-        "INSERT INTO \"anycable_broadcasts\" (payload) VALUES ($1)",
-        [{stream: "notification", data: "hello!"}.to_json]
+        "SELECT anycable_publish($1, $2, $3)",
+        [
+          "notification",
+          {stream: "notification", data: "hello!"}.to_json,
+          "{}"
+        ]
+      )
+    end
+
+    it "publishes each batched message through the Postgres function" do
+      allow(pg_conn).to receive(:exec_params)
+
+      adapter = described_class.new
+      adapter.batching do
+        adapter.broadcast("notification", "hello!")
+        adapter.broadcast("chat", "hi!", exclude_socket: "42")
+      end
+
+      expect(pg_conn).to have_received(:exec_params).with(
+        "SELECT anycable_publish($1, $2, $3)",
+        [
+          "notification",
+          {stream: "notification", data: "hello!"}.to_json,
+          "{}"
+        ]
+      )
+
+      expect(pg_conn).to have_received(:exec_params).with(
+        "SELECT anycable_publish($1, $2, $3)",
+        [
+          "chat",
+          {stream: "chat", data: "hi!", meta: {exclude_socket: "42"}}.to_json,
+          {exclude_socket: "42"}.to_json
+        ]
       )
     end
   end
 
   describe "#broadcast_command" do
-    it "inserts command data into the broadcast table" do
+    it "publishes command data through the Postgres function" do
       allow(pg_conn).to receive(:exec_params)
 
       adapter = described_class.new
       adapter.broadcast_command("disconnect", identifier: "42")
 
       expect(pg_conn).to have_received(:exec_params).with(
-        "INSERT INTO \"anycable_broadcasts\" (payload) VALUES ($1)",
-        [{command: "disconnect", payload: {identifier: "42"}}.to_json]
+        "SELECT anycable_remote_command($1, $2)",
+        [
+          {command: "disconnect", payload: {identifier: "42"}}.to_json,
+          "{}"
+        ]
       )
     end
   end
 
-  describe "contract validation" do
-    before do
-      config.postgres_validate_contract = true
-    end
+  describe "#raw_broadcast" do
+    it "rejects payloads without stream or command" do
+      adapter = described_class.new
 
-    let(:version_result) do
-      instance_double("PG::Result", ntuples: 1, getvalue: "1")
-    end
-
-    let(:columns_result) do
-      [
-        {"attname" => "id", "format_type" => "bigint", "attnotnull" => "t"},
-        {"attname" => "payload", "format_type" => "text", "attnotnull" => "t"},
-        {"attname" => "claimed_by", "format_type" => "text", "attnotnull" => "f"},
-        {"attname" => "claimed_at", "format_type" => "timestamp with time zone", "attnotnull" => "f"},
-        {"attname" => "attempts", "format_type" => "integer", "attnotnull" => "t"},
-        {"attname" => "last_error", "format_type" => "text", "attnotnull" => "f"},
-        {"attname" => "created_at", "format_type" => "timestamp with time zone", "attnotnull" => "t"}
-      ]
-    end
-
-    let(:trigger_result) do
-      instance_double("PG::Result", getvalue: "t")
-    end
-
-    it "checks contract version, columns, and trigger" do
-      allow(pg_conn).to receive(:exec_params).and_return(version_result, columns_result, trigger_result)
-
-      expect { described_class.new }.not_to raise_error
-      expect(pg_conn).to have_received(:exec_params).with(
-        a_string_matching(/tgenabled <> 'D'.*\(tgtype::int & 4\) = 4/m),
-        ["anycable_broadcasts", described_class::BROADCASTS_TRIGGER_NAME]
-      )
-    end
-
-    it "fails when the contract row is missing" do
-      missing_version = instance_double("PG::Result", ntuples: 0)
-      allow(pg_conn).to receive(:exec_params).and_return(missing_version)
-
-      expect { described_class.new }.to raise_error(/contract version mismatch/)
+      expect { adapter.raw_broadcast({data: "hello!"}.to_json) }.to raise_error(ArgumentError, /stream or command/)
     end
   end
 end

--- a/spec/anycable/config_spec.rb
+++ b/spec/anycable/config_spec.rb
@@ -191,17 +191,11 @@ describe AnyCable::Config do
   describe "#to_postgres_params" do
     before do
       config.postgres_url = "postgres://postgres-1/anycable"
-      config.postgres_broadcasts_table = "anycable_broadcasts"
-      config.postgres_contract_table = "anycable_contracts"
-      config.postgres_validate_contract = true
     end
 
     specify do
       expect(subject.to_postgres_params).to eq(
-        url: "postgres://postgres-1/anycable",
-        broadcasts_table: "anycable_broadcasts",
-        contract_table: "anycable_contracts",
-        validate_contract: true
+        url: "postgres://postgres-1/anycable"
       )
     end
   end

--- a/spec/anycable/config_spec.rb
+++ b/spec/anycable/config_spec.rb
@@ -188,6 +188,24 @@ describe AnyCable::Config do
     end
   end
 
+  describe "#to_postgres_params" do
+    before do
+      config.postgres_url = "postgres://postgres-1/anycable"
+      config.postgres_broadcasts_table = "anycable_broadcasts"
+      config.postgres_contract_table = "anycable_contracts"
+      config.postgres_validate_contract = true
+    end
+
+    specify do
+      expect(subject.to_postgres_params).to eq(
+        url: "postgres://postgres-1/anycable",
+        broadcasts_table: "anycable_broadcasts",
+        contract_table: "anycable_contracts",
+        validate_contract: true
+      )
+    end
+  end
+
   describe "defaults" do
     subject(:config) { described_class.new }
 


### PR DESCRIPTION
## Summary

Adds a Postgres broadcast adapter to AnyCable Ruby:

- `broadcast_adapter: postgres`
- calls the SQL functions owned by anycable-go: `anycable_publish(stream, payload, meta)` and `anycable_remote_command(payload, meta)`
- preserves the full AnyCable JSON envelope as opaque text for the server-owned schema
- supports normal stream broadcasts, remote commands, and batched broadcasts by decomposing the batch into one SQL function call per message
- documents the adapter/config and adds RBS signatures, focused specs, and a changelog entry

The adapter pairs with anycable-go's Postgres implementation. PostgreSQL `LISTEN/NOTIFY` stays in anycable-go as a wake-up path; the Ruby producer does not manage signalling tables, triggers, or schema validation.

## Config

New config key:

- `postgres_url` (`ANYCABLE_POSTGRES_URL`, defaults through `DATABASE_URL` before falling back to localhost)

## Validation

- `bundle exec rspec spec/anycable/broadcast_adapters/postgres_spec.rb spec/anycable/config_spec.rb`
- `bundle exec rubocop lib/anycable/broadcast_adapters/postgres.rb lib/anycable/config.rb spec/anycable/broadcast_adapters/postgres_spec.rb spec/anycable/config_spec.rb`
- `git diff --check`

## Follow-Up

- The anycable-go PR owns schema creation/validation and consumes the SQL-function writes.
- The anycable-rails PR configures generated apps for this server-owned schema.

## Development Note

This PR was prepared with AI assistance and then reviewed, tested, and validated by TikiTDO before submission.

## Related PRs

- anycable-go Postgres consumer/pubsub: https://github.com/anycable/anycable/pull/306
- anycable-rails setup generator: https://github.com/anycable/anycable-rails/pull/223
- graphql-anycable support: https://github.com/anycable/graphql-anycable/pull/54

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
